### PR TITLE
임영찬 : hackerrank The PADS

### DIFF
--- a/lim8662/hackerrank/the-pads.sql
+++ b/lim8662/hackerrank/the-pads.sql
@@ -1,0 +1,8 @@
+select CONCAT(name, '(', LEFT(occupation, 1) ,')') 
+from occupations 
+order by name;
+
+select CONCAT('There are a total of ', count(*), ' ', LOWER(occupation),'s.') as result 
+from occupations 
+group by occupation
+order by result;


### PR DESCRIPTION
#  The PADS
[문제 보러가기](https://www.hackerrank.com/challenges/the-pads/problem?isFullScreen=true&h_r=next-challenge&h_v=zen)

## 🅰 설계

문자열을 합치는 `CONCAT()`함수를 활용하여 풀었습니다.
 
1. 이름(직업 첫글자)
```sql
select CONCAT(name, '(', LEFT(occupation, 1) ,')') 
from occupations 
order by name;
```

필드명과 함수를 인자로 원하는 문자열을 만들었습니다.

직업은 `LEFT()`함수를 사용해 첫 글자만 추출하였습니다.

---

2. There are a total of 2 doctors.
```
select CONCAT('There are a total of ', count(*), ' ', LOWER(occupation),'s.') as result 
from occupations 
group by occupation
order by result;

```

직업의 수 -> 직업명 순의 다중 오름차순 정렬은 전체 결과의 오름차순으로 정렬하였습니다.

## ✅ 후기
