### PR TITLE
이정환 : BOJ 9095 1,2,3 더하기

### DIFF
--- a/edd0718/backjoon/9095.cpp
+++ b/edd0718/backjoon/9095.cpp
@@ -1,0 +1,22 @@
+// boj 9096 - 1,2,3 더하기
+#include <iostream>
+#define MAX 11
+
+void DP() {
+    int P[MAX], n;
+    std::cin >> n;
+    P[1]=1, P[2]=2, P[3]=4;
+    for (int i=4; i<=n; i++) {
+        P[i] = P[i-1] + P[i-2] + P[i-3];
+    }
+    std::cout << P[n] << std::endl;
+}
+
+int main() {
+    int tc;
+    std::cin >> tc;
+    for (int i=0; i<tc; i++) {
+        DP();
+    }
+    return 0;
+}


### PR DESCRIPTION
# 1,2,3 더하기
[문제 보러가기](https://www.acmicpc.net/problem/9095)

## 🅰 설계
1, 2, 3을 만드는 각각의 경우의 수를 안다면, 
P[i] = P[i-1] +P[i-2] + P[i-3]의 점화식을 유추할 수 있습니다.
P배열에 선언 및 저장하여 구현하였습니다.

``` cdouple
// boj 9095 - 1,2,3 더하기
#include <iostream>

void DP() {
    int P[11], n;
    std::cin >> n;
    P[1] = 1, P[2] = 2, P[3] = 4;
    for (int i=4; i<=n; i++) {
        P[i] = P[i-1] + P[i-2] + P[i-3];
    }
    std::cout << P[n] << std::endl;
}

int main() {
    int tc;
    std::cin >> tc;
    for (int i=0; i<tc; i++) {
        DP();
    }
    return 0;
}
```

## ✅ 후기
재귀로 구현할 수도 있을거란 생각을 했습니다.