### PR TITLE
하현숙 : let 16 3Sum Closet

### DIFF
--- a/hyeonsook95/leetcode/16.py
+++ b/hyeonsook95/leetcode/16.py
@@ -1,0 +1,19 @@
+class Solution:
+    def threeSumClosest(self, nums, target):
+        nums = sorted(nums)
+        result = sum(nums[:3])
+        for idx in range(len(nums) - 2):
+            # left와 right를 양 끝 인덱스 값으로 초기화
+            left, right = idx + 1, len(nums) - 1
+            while left < right:
+                p_sum = nums[idx] + nums[left] + nums[right]
+                if abs(target - p_sum) < abs(target - result):
+                    result = p_sum
+                if result == target:
+                    return result
+
+                if p_sum > target:
+                    right -= 1
+                else:
+                    left += 1
+        return result

--- a/hyeonsook95/leetcode/16.ts
+++ b/hyeonsook95/leetcode/16.ts
@@ -1,0 +1,24 @@
+function threeSumClosest(nums: number[], target: number): number {
+    nums.sort(function (a, b) { return a - b; });
+    var result = nums[0] + nums[1] + nums[2];
+    for (var idx = 0; idx < nums.length; idx++) {
+        var left: number = idx + 1;
+        var right: number = nums.length - 1;
+        while (left < right) {
+            let pSum = nums[idx] + nums[left] + nums[right];
+            if (Math.abs(target - pSum) < Math.abs(target - result)) {
+                result = pSum;
+            }
+            if (result === target) {
+                return result;
+            }
+
+            if (pSum > target) {
+                right -= 1;
+            } else {
+                left += 1;
+            }
+        }
+    }
+    return result;
+};


### PR DESCRIPTION
# 16 3Sum Closet
[문제 보러가기](https://leetcode.com/problems/3sum-closest/)

## 🅰 설계

### 1. 모든 경우의 수 계산해보기

가장 간단하게 모든 경우의 수를 계산하는 방법으로 시도했습니다. `Time Limit Exceeded` 이 나와서 실패했습니다.

[leetcode 코드 보기](https://leetcode.com/submissions/detail/668985865/)

수의 개수가 최대 1000개이고, 시간복잡도가 1000! 이었으므로 당연한 결과였습니다.

### 2. 투 포인터로 구하기

두 수의 합이 `target`과 가장 비슷한 숫자를 출력하는 문제를 풀어보았던 기억이 떠올라 같은 아이디어로 시도했습니다.

3개의 포인터이기 때문에 어떻게 접근할 지 생각하다가 한 개의 포인터 값을 고정하고 남은 범위에서 2개의 포인터로 값을 구하는 아이디어를 생각했습니다.

```python3
for idx in range(len(nums)-2):
  left, right = idx+1, len(nums)-1
  while left < right:
    ...
```

세 수의 합이 `target`과 가장 가까워야 하기 때문에 두 개의 포인터를 사용하여 `target`과 가장 가까운 값으로 향하는 로직을 구현해야 했습니다.

수의 합을 구할 때, 가장 일반적으로 사용하는 수를 정렬하고, `target`보다 클 경우 더하는 값을 더 작도록/ `target`보다 작을 경우 더하는 값이 더 커지도록 하는 방법을 사용하였습니다.

```python3
class Solution:
    def threeSumClosest(self, nums, target):
        nums = sorted(nums)
        result = sum(nums[:3])
        for idx in range(len(nums)-2):
            left, right = idx+1, len(nums)-1
            while left < right:
                p_sum = nums[idx] + nums[left] + nums[right]
                if abs(target-p_sum) < abs(target-result):
                    result = p_sum
                if result == target:
                    return result
                
                if p_sum > target:
                    right -= 1
                else:
                    left += 1
        return result
```

## ✅ 후기
투 포인터 아이디어는 쉽게 생각해냈으나 3개의 포인터를 어떻게 해야할지 잘 떠올리지 못했습니다.

모든 경우의 수를 계산하고, 한 숫자에서 나올 수 있는 target과 가장 가까운 값을 고정된 값 이후의 값들로 합을 구하면 숫자들 각각에서 가장 최선의 합을 구할 수 있다는 것을 간과했기 때문입니다.

이전에 풀었던 투 포인터 문제들을 날림으로 풀었다는 점이 느껴져서 많이 반성했습니다.