### PR TITLE
하현숙 : boj 1913 달팽이

### DIFF
--- a/hyeonsook95/baekjoon/1913.py
+++ b/hyeonsook95/baekjoon/1913.py
@@ -1,0 +1,24 @@
+import sys
+
+input = sys.stdin.readline
+
+N = int(input().strip())
+maps = [[0 for _ in range(N)] for _ in range(N)]
+
+dr, dc = [1, 0, -1, 0], [0, 1, 0, -1]
+
+d_idx = 0
+r_idx, c_idx = 0, 0
+for num in range(N**2, 0, -1):
+    maps[r_idx][c_idx] = num
+    if not (
+        -1 < r_idx + dr[d_idx] < N
+        and -1 < c_idx + dc[d_idx] < N
+        and maps[r_idx + dr[d_idx]][c_idx + dc[d_idx]] == 0
+    ):
+        d_idx = (d_idx + 1) % 4
+    r_idx += dr[d_idx]
+    c_idx += dc[d_idx]
+
+for m in maps:
+    print(*m, sep=" ", end="\n")

--- a/hyeonsook95/baekjoon/1913.py
+++ b/hyeonsook95/baekjoon/1913.py
@@ -3,6 +3,9 @@ import sys
 input = sys.stdin.readline
 
 N = int(input().strip())
+target = int(input().strip())
+
+nr, nc = -1, -1
 maps = [[0 for _ in range(N)] for _ in range(N)]
 
 dr, dc = [1, 0, -1, 0], [0, 1, 0, -1]
@@ -10,6 +13,8 @@ dr, dc = [1, 0, -1, 0], [0, 1, 0, -1]
 d_idx = 0
 r_idx, c_idx = 0, 0
 for num in range(N**2, 0, -1):
+    if num == target:
+        nr, nc = r_idx, c_idx
     maps[r_idx][c_idx] = num
     if not (
         -1 < r_idx + dr[d_idx] < N
@@ -21,4 +26,5 @@ for num in range(N**2, 0, -1):
     c_idx += dc[d_idx]
 
 for m in maps:
-    print(*m, sep=" ", end="\n")
+    print(*m, end="\n")
+print(nr + 1, nc + 1)

--- a/hyeonsook95/baekjoon/1913.ts
+++ b/hyeonsook95/baekjoon/1913.ts
@@ -1,0 +1,36 @@
+var fs = require("fs");
+var input = fs.readFileSync('dev/stdin').toString().split('\n');
+
+const N = parseInt(input[0]);
+const target = parseInt(input[1]);
+
+var tr = -1;
+var tc = -1;
+var maps = Array.from(Array(N), () => Array(N).fill(0));
+
+var didx = 0;
+const dr = [1, 0, -1, 0];
+const dc = [0, 1, 0, -1];
+
+var ridx = 0;
+var cidx = 0;
+
+for (var num = N ** 2; num > 0; num--) {
+    if (num === target) {
+        tr = ridx + 1;
+        tc = cidx + 1;
+    }
+
+    maps[ridx][cidx] = num;
+    if ((0 > ridx + dr[didx]) || (N - 1 < ridx + dr[didx]) || (0 > cidx + dc[didx]) || (N - 1 < cidx + dc[didx]) || (maps[ridx + dr[didx]][cidx + dc[didx]] !== 0)) {
+        didx = (didx + 1) % 4;
+    }
+    ridx = ridx + dr[didx];
+    cidx = cidx + dc[didx];
+
+}
+
+for (var row of maps) {
+    console.log(...row);
+}
+console.log(tr, tc);


### PR DESCRIPTION
# 1913 달팽이
[문제 보러가기](https://boj.kr/1913)

## 🅰 설계

2차원 이상의 배열 문제를 풀 때는 어떤 규칙으로 배열을 움직이는지를 찾는 게 포인트입니다.

이전에는 움직이는 규칙을 찾으려고 노력하였으나, 이번에는 움직이지 않는 규칙을 찾아서 문제를 해결하였습니다.

**배열의 크기를 넘어서 이동하면 안된다**거나 0으로 초기화된 배열에서 값을 채워나가는 로직인데, 이미 **값이 채워져 있다면 배열의 값을 채우지 않아야 한다**는 규칙을 찾고, 해당 규칙의 조건을 만족하면 방향을 전환하여 다른 칸으로 이동하도록 하였습니다.

```python3
...
if not (
        -1 < r_idx + dr[d_idx] < N
        and -1 < c_idx + dc[d_idx] < N
        and maps[r_idx + dr[d_idx]][c_idx + dc[d_idx]] == 0
    ):
        d_idx = (d_idx + 1) % 4
...
```

규칙을 만족시켜 방향을 전환하거나 전환하지 않더라도 `N**2`의 숫자를 2차원 배열에 채워야하므로 for문을 통해 `N**2`번 반복하도록 하였습니다.

```python3
N = int(input().strip())
number = int(input().strip())

maps = [[0 for _ in range(N)] for _ in range(N)]
nr, nc = -1, -1
dr, dc = [1, 0, -1, 0], [0, 1, 0, -1]

d_idx = 0
r_idx, c_idx = 0, 0
for num in range(N**2, 0, -1):
    if num == number:
        nr, nc = r_idx + 1, c_idx + 1
    maps[r_idx][c_idx] = num
    if not (
        -1 < r_idx + dr[d_idx] < N
        and -1 < c_idx + dc[d_idx] < N
        and maps[r_idx + dr[d_idx]][c_idx + dc[d_idx]] == 0
    ):
        d_idx = (d_idx + 1) % 4
    r_idx += dr[d_idx]
    c_idx += dc[d_idx]
````



## ✅ 후기
달팽이와 관련된 문제는 이전에 몇 번 풀어보았습니다.

이전에 문제를 풀 때는 이동 조건을 만족하여 이동하도록 하는데 중점을 두었으나 이번에는 이동하지 않아야하는 경우의 조건을 찾는데 중점을 두었습니다.

아래의 경우가 훨씬 간단한 로직이 나와서 간결한 코드가 나왔습니다. 뿌듯하네요.