### PR TITLE
이정환 : leet 16 3Sum closest

### DIFF
--- a/edd0718/backjoon/1913.cpp
+++ b/edd0718/backjoon/1913.cpp
@@ -1,0 +1,48 @@
+// boj 1913 - 달팽이
+#include <iostream>
+using namespace std;
+
+int main() {
+    int x = 0, y = 0;
+    int key = 1;
+    int n, m, idx, idy;
+    std::cin >> n;
+    std::cin >> m;
+    int num = n*n;
+    int D[n][n];
+    for (int i=0; i<n; i++) {
+        for (int j=0; j<n; j++) {
+            D[i][j] = 0;
+        }
+    }
+    
+    for (int k=0; k<n; k++) {
+        D[x][y] = num--;
+        x += key;
+    }
+    x -= 1;
+    for (int i=n-1; i>0; i--) {
+        for (int j=0; j<i; j++) {
+            y += key;
+            D[x][y] = num--;
+        }
+        key *= -1;
+        for (int k=0; k<i; k++) {
+            x += key;
+            D[x][y] = num--;
+        }
+    }
+
+    for (int i=0; i<n; i++) {
+        for (int j=0; j<n; j++) {
+            if (D[i][j] == m) {
+                idx = i+1;
+                idy = j+1;
+            }
+            std::cout << D[i][j] << ' ';
+        }
+        std::cout << std::endl;
+    }
+    std::cout << idx << ' ' << idy << std::endl;
+    return 0;
+}

--- a/edd0718/leetcode/leet-16.cpp
+++ b/edd0718/leetcode/leet-16.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#define INF 2000000000
+using namespace std;
+
+int main() {
+    int n, trg, res;
+    std::cin >> n;
+    vector<int> num(n);
+    for (int i=0; i<n; i++) {
+        std::cin >> num[i];
+    }
+    std::cin >> trg;
+    sort(num.begin(), num.end());
+    vector<int> ans(3);
+    
+    int start = 0;
+    int end = n-1;
+    int key = start+1;
+    int close = INF;
+    while (start < end && key < end) {
+        int sum = num[start] + num[key] + num[end];
+        if (sum != trg) {
+            if (abs(sum-trg) < close) {
+                close = abs(sum-trg);
+                ans[0] = num[start];
+                ans[1] = num[key];
+                ans[2] = num[end];
+            }
+            if (key == end-1) {
+                start++;
+                key = start;
+            }
+            key++;
+        }
+        else {
+            ans[0] = num[start];
+            ans[1] = num[key];
+            ans[2] = num[end];
+            break;
+        }
+    }
+    res = ans[0]+ans[1]+ans[2];
+    std::cout << res << std::endl;
+    return 0;
+}


### PR DESCRIPTION
# 16 3Sum Closest
[문제 보러가기](https://leetcode.com/problems/3sum-closest/)

## 🅰 설계

먼저 문제를 읽고, 투포인터 문제로 생각하고 접근하였습니다.
합에 가까운 타겟을 찾아야해서 기존의 합과 새로운 합의 절대값 차이를 생각하였고,
오름차순으로 정렬하여 비교하다보니 세개의 포인터가 필요하다고 생각해서,
그대로 구현하였습니다.

```cdouple
#include <iostream>
#include <vector>
#include <algorithm>
#define INF 2000000000
using namespace std;

int main() {
    int n, trg, res;
    std::cin >> n;
    vector<int> num(n);
    for (int i=0; i<n; i++) {
        std::cin >> num[i];
    }
    std::cin >> trg;
    sort(num.begin(), num.end());
    vector<int> ans(3);
    
    int start = 0;
    int end = n-1;
    int key = start+1;
    int close = INF;
    while (start < end && key < end) {
        int sum = num[start] + num[key] + num[end];
        if (sum != trg) {
            if (abs(sum-trg) < close) {
                close = abs(sum-trg);
                ans[0] = num[start];
                ans[1] = num[key];
                ans[2] = num[end];
            }
            if (key == end-1) {
                start++;
                key = start;
            }
            key++;
        }
        else {
            ans[0] = num[start];
            ans[1] = num[key];
            ans[2] = num[end];
            break;
        }
    }
    res = ans[0]+ans[1]+ans[2];
    std::cout << res << std::endl;
    return 0;
}
```

## ✅ 후기
더 나은 방법이 있지않을까 다시한번 고민해봐야겠습니다.