### PR TITLE
하현숙 : boj 10025 게으른 백곰

### DIFF
--- a/hyeonsook95/baekjoon/10025.py
+++ b/hyeonsook95/baekjoon/10025.py
@@ -1,0 +1,24 @@
+import sys
+
+input = sys.stdin.readline
+
+maps = [0] * 1000001
+
+N, K = map(int, input().strip().split(" "))
+
+for _ in range(N):
+    ice, idx = map(int, input().strip().split(" "))
+    maps[idx] = ice
+
+result = sum(maps[: 2 * K])
+p_sum = result
+left, right = 0, 2 * K
+while right < 1000000:
+    left += 1
+    right += 1
+
+    p_sum = p_sum - maps[left - 1] + maps[right]
+    result = max(result, p_sum)
+
+
+print(result)

--- a/hyeonsook95/baekjoon/10025.ts
+++ b/hyeonsook95/baekjoon/10025.ts
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const input = fs.readFileSync('dev/stdin').toString().trim().split('\n');
+
+const [N, K] = input[0].split(' ').map(num => parseInt(num));
+var maps = Array(1000001).fill(0);
+
+for (var inputIdx = 0; inputIdx < N; inputIdx++) {
+    var [ice, idx] = input[inputIdx + 1].trim().split(' ').map(num => parseInt(num));
+    maps[idx] = ice;
+}
+
+var result = 0;
+var end = (2 * K + 1) > 1000001 ? 1000001 : (2 * K + 1);
+for (var idx = 0; idx < end; idx++) {
+    result += maps[idx];
+}
+var left = 0;
+var right = 2 * K;
+var pSum = result;
+while (right < 1000000) {
+    left += 1;
+    right += 1;
+
+    pSum = pSum - maps[left - 1] + maps[right];
+    result = pSum > result ? pSum : result;
+}
+
+console.log(result);

--- a/hyeonsook95/baekjoon/10025.ts
+++ b/hyeonsook95/baekjoon/10025.ts
@@ -14,6 +14,7 @@ var end = (2 * K + 1) > 1000001 ? 1000001 : (2 * K + 1);
 for (var idx = 0; idx < end; idx++) {
     result += maps[idx];
 }
+
 var left = 0;
 var right = 2 * K;
 var pSum = result;


### PR DESCRIPTION
# Selection Sum
[문제 보러가기](https://boj.kr/10025)

## 🅰 설계
앨버트가 움직일 수 있는 거리가 `K` 만큼 좌우이므로, 배열에서 고정된 크기로 움직이며 합을 구하면 되겠다고 생각했습니다.

그래서 0번째 인덱스에서 K*2 인덱스 까지 합을 구하고, left와 right로 K*2만큼 크기를 고정한 후에 이동하면서 합의 크기를 비교하였습니다.

처음에는 `sum`을 사용하여 매번 합을 구했으나, 실행 속도를 줄이고자 left-1값을 빼고 right 값을 더하여 해당 윈도우의 합을 구했습니다.

```python3
result = sum(maps[: 2 * K])
p_sum = result
left, right = 0, 2 * K
while right < 1000000:
    left += 1
    right += 1

    p_sum = p_sum - maps[left - 1] + maps[right]
    result = max(result, p_sum)
```


python으로 풀 때는 대체로 배열의 크기에 대해 크게 생각하지 않는데요. 그런 점 때문에 js로 문제를 풀면서 오류에 한참 헤맸습니다. 🤔

로직은 python과 똑같이 구현하였으나, 답이 틀렸다고 나왔고, 문제가 생겼던 부분은 아래의 `maps` 초기화와  루프문이었습니다.

```typescript
var maps = Array(1000001).fill(0);

var result = 0;
for (var idx = 0; idx < (2*K)+1; idx++) {
    result += maps[idx];
}
```

`maps`는 얼음 양동이의 좌표가 될 수 있는 `x` 값의 범위로 초기화시켰었습니다. `0 <=x <=1,000,000` 이었기 때문에 `maps`의 크기를 1,000,001로 하였습니다.

`슬라이딩 윈도우`를 위한 윈도우의 크기는 앨버트가 이동할 수 있는 거리는 좌우로 K만큼이었기 때문에 `2*K`로 간단히 생각했습니다.

그러나 `1 <= K <= 2,000,000`이었기 때문에 `2*K`의 크기는 최대 4,000,000이 될 수 있었고, 미리 초기화시켜둔 `maps`의 크기를 넘게 됩니다.

하지만 js 특성상 초기화 시켜준 array의 크기를 넘어가도 오류를 출력하지 않고, 그대로 실행하고 답은 `NaN` (Not is A Number)로 틀린 답을 출력하게 되었습니다.

해당 문제는 루프문의 최대 크기를 1000001로 제한하여 해결하였습니다.

```typescript
var result = 0;
var end = (2 * K + 1) > 1000001 ? 1000001 : (2 * K + 1);
for (var idx = 0; idx < end; idx++) {
    result += maps[idx];
}
```

## ✅ 후기
c++이었으면 에러문을 출력했을 것이고, python이라면 인덱스로 참조하지 않았을 테니 js가 가진 언어적 특성 때문에 빨리 발견하지 못했던 오류였습니다.

많이 공부가 되었습니다. 😀