### PR TITLE
심규환 : boj 10798 세로읽기

### DIFF
--- a/sgh1939/baekjoon/10798.cpp
+++ b/sgh1939/baekjoon/10798.cpp
@@ -1,0 +1,30 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main(){
+   int arr[5][15] = {0,};
+
+   for(int i=0; i<5; i++){
+      for(int j=0; j<15; j++){
+         arr[i][j] = 64;
+      }
+   }
+
+   for(int i=0; i<5; i++){
+      string s;
+      getline(cin, s);
+      for(int j=0; j<s.size(); j++){
+         arr[i][j] = s[j];
+      }
+   }
+   
+   for(int i=0; i<15; i++){
+      for(int j=0; j<5; j++){
+         if(arr[j][i]== 64) continue;
+         cout<<(char)arr[j][i];
+      }
+   } 
+   
+   return 0;
+}
+


### PR DESCRIPTION
범위 자체가 크지 않아서 모든 범위를 '@' 값으로 초기화 한 뒤, '@'을 제외하고 출력하게 했습니다.  