### PR TITLE
하현숙 : boj 2302 dp 극장좌석

### DIFF
--- a/hyeonsook95/baekjoon/2302.py
+++ b/hyeonsook95/baekjoon/2302.py
@@ -1,0 +1,20 @@
+import sys
+
+input = sys.stdin.readline
+dp = [1, 1, 2, 3]  # dp 초기화
+
+N = int(input())
+# N은 최대 40까지이므로 dp의 최대 길이도 40, O(N) = 40
+while N > len(dp) - 1:
+    dp.append(dp[-1] + dp[-2])
+
+M = [int(input()) for _ in range(int(input()))]
+
+if not M:
+    print(dp[N])
+else:
+    M.append(N + 1)
+    answer = dp[M[0] - 1]
+    for idx in range(1, len(M)):
+        answer *= dp[M[idx] - M[idx - 1] - 1]
+    print(answer)


### PR DESCRIPTION
# Selection Sum
[문제 보러가기](https://boj.kr/2302)

## 🅰 설계

### 1. DFS로 접근

경우의 수 문제라고 생각했기 때문에 dfs로 접근했습니다. 하지만 dfs로 나온 값이 너무 컸기 때문에 다른 방법으로 접근해야겠다고 생각했습니다.

### 2. DP로 접근

DFS로의 접근을 고민하다 보니 경우의 수와 관련된 알고리즘만 떠올리며 1시간이 지나 문제 유형을 살펴보고 풀었습니다. DP라는 문제 유형을 알아내면 비교적 쉽게 해결할 수 있는 문제였습니다.

구현해야 할 연산 부분은 `DP의 점화식` 부분과 `VIP가 주어질 경우, 경우의 수를 나눠서 연산`하는 과정입니다.
DP 점화식은 N=5일 때까지 계산해보고 구할 수 있었습니다. `dp[n] = dp[n-1]+dp[n-2]` dp의 연산이 `n-1` index와 `n-2` index를 더하는 값이므로 최소 n=2까지는 dp를 초기화해야 했습니다. 저는 주로 3까지 초기화하므로 이번에도 3까지 초기화했습니다.

```python3
dp = [1, 1, 2, 3]
```
다음은 경우의 수를 나눠서 연산하는 부분입니다.

VIP가 주어질 경우, VIP 값을 기준으로 만들어질 수 있는 패턴이 제한되게 됩니다. 그리고 VIP 값을 기준으로 각 패턴은 연관 관계가 없으므로 경우의 수를 구할 때, `*` 연산을 해줘야 합니다.

저는 m 값을 입력으로 받고, m 값으로 반복문을 돌려 이전의 m값과의 차이를 계산하여 연산하였습니다.

```python3
    M.append(N + 1)
    answer = dp[M[0] - 1]
    for idx in range(1, len(M)):
        answer *= dp[M[idx] - M[idx - 1] - 1]
```

`M`에 `append`를 해준 이유는 마지막으로 주어진 VIP가 좌석의 끝이 아닐 경우, 마지막 VIP를 기준으로 뒤의 좌석의 경우를 곱하지 않기 때문입니다.

`answe *= dp` 연산을 중복해서 사용하고 싶지 않았기 때문에 M 리스트에 임의의 마지막 VIP를 넣어주어 연산하도록 하였습니다.


## ✅ 후기

dp 초기화는 문제를 한 번 틀리고 바꿔주었습니다. 좌석의 모든 고객이 VIP일 경우에 루프문을 도는 연산과정에서 0이 들어가며 정답이 0으로 출력되었기 때문입니다.

dp 초기화를 할 때 신경써야할 것 같습니다. 😅 