### PR TITLE
이정환 : boj 2302 구현 극장좌석

### DIFF
--- a/edd0718/backjoon/2302.cpp
+++ b/edd0718/backjoon/2302.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <vector>
+using namespace std;
+#define MAX 40
+
+int main() {
+    int n, m;
+    int answer = 1;
+    std::cin >> n;
+    std::cin >> m;
+    vector<int> DP(MAX);
+    vector<int> VIP(MAX);
+    for (int i=0; i<m; i++) {
+        std::cin >> VIP[i];
+    }
+    // vip x -> 경우의 수
+    DP[1]=1, DP[2]=2;
+    for (int i=3; i<=n; i++) {
+        DP[i] = DP[i-2] + DP[i-1];
+    }
+    // vip o -> 경우의 수 (누적곱)
+    int key=0;
+    for (int i=0; i<m; i++) {
+        answer *= DP[VIP[i] - key - 1];
+        key = VIP[i];
+    }
+    answer *= DP[n-key];
+    std::cout << answer << std::endl;
+    return 0;
+}


### PR DESCRIPTION
# 극장좌석
[문제 보러가기](https://boj.kr/2302)

## 🅰 설계

### 구현
vip의 좌석 배치 조건과 일반 배치 조건이 다르기 때문에, 경우의 수를 나누어서 생각해보았다.
먼저 vip가 없을 때의 경우의 수는 다음의 점화식으로 해결하였다.
```cdouple
    DP[1]=1, DP[2]=2;
    for (int i=3; i<=n; i++) {
        DP[i] = DP[i-2] + DP[i-1];
    }
```
vip가 있는 경우, 위치가 고정된 vip좌석 사이의 일반 배치 경우의 수를 구할 수 있다.
처음좌석부터 vip사이의 경우의 수와 vip와 다음 vip사이의 경우의 수를 누적곱을 통해 구한다.
반복문에 포함되지 않은 마지막 vip좌석과 좌석끝까지의 경우의 수를 한번더 곱해준다.
```cdouple
    int key=0;
    for (int i=0; i<m; i++) {
        answer *= DP[VIP[i] - key - 1];
        key = VIP[i];
    }
    answer *= DP[n-key];
```
전체코드
```cdouple
#include <iostream>
#include <vector>
using namespace std;
#define MAX 40

int main() {
    int n, m;
    int answer = 1;
    std::cin >> n;
    std::cin >> m;
    vector<int> DP(MAX);
    vector<int> VIP(MAX);
    for (int i=0; i<m; i++) {
        std::cin >> VIP[i];
    }
    // vip x -> 경우의 수
    DP[1]=1, DP[2]=2;
    for (int i=3; i<=n; i++) {
        DP[i] = DP[i-2] + DP[i-1];
    }
    // vip o -> 경우의 수 (누적곱)
    int key=0;
    for (int i=0; i<m; i++) {
        answer *= DP[VIP[i] - key - 1];
        key = VIP[i];
    }
    answer *= DP[n-key];
    std::cout << answer << std::endl;
    return 0;
}
```

## ✅ 후기
다른 방법으로 풀 수 있는지 더 고민해보아야겠다.