### PR TITLE
이정환 : boj 11726 dp 2xn 타일링

### DIFF
--- a/edd0718/backjoon/11726.cpp
+++ b/edd0718/backjoon/11726.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+#include <stack>
+#define REM 10007
+
+int main() {
+    int n;
+    std::cin >> n;
+    int dp[1000];
+    dp[1]=1, dp[2]=2;
+
+    for (int i=3; i<=n; i++) {
+        dp[i] = (dp[i-2] + dp[i-1]) % REM;
+    }
+
+    std::cout << dp[n] << std::endl;
+    return 0;
+}

--- a/edd0718/backjoon/2302.cpp
+++ b/edd0718/backjoon/2302.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <vector>
+using namespace std;
+#define MAX 40
+
+int main() {
+    int n, m;
+    int answer = 1;
+    std::cin >> n;
+    std::cin >> m;
+    vector<int> DP(MAX);
+    vector<int> VIP(MAX);
+    for (int i=0; i<m; i++) {
+        std::cin >> VIP[i];
+    }
+    // vip x -> 경우의 수
+    DP[1]=1, DP[2]=2;
+    for (int i=3; i<=n; i++) {
+        DP[i] = DP[i-2] + DP[i-1];
+    }
+    // vip o -> 경우의 수 (누적곱)
+    int key=0;
+    for (int i=0; i<m; i++) {
+        answer *= DP[VIP[i] - key - 1];
+        key = VIP[i];
+    }
+    answer *= DP[n-key];
+    std::cout << answer << std::endl;
+    return 0;
+}


### PR DESCRIPTION
# 2xn 타일링
[문제 보러가기](https://boj.kr/11726)

## 🅰 설계
1x2, 2x1 각각의 타일로 특정 n값을 정해 2xn 범위를 채울 수 있는 경우의 수를 직접 그려보았고,
해당 코드의 점화식으로 구현하였다.

```cdouple
#include <iostream>
#define REM 10007

int main() {
    int n;
    std::cin >> n;
    int dp[1000];
    dp[1]=1, dp[2]=2;

    for (int i=3; i<=n; i++) {
        dp[i] = (dp[i-2] + dp[i-1]) % REM;
    }

    std::cout << dp[n] << std::endl;
    return 0;
}
```

## ✅ 후기
처음 문제를 접하고, 가로의 길이를 홀짝으로 나누어 계산하였는데 
왜그랬는지 모르겠음.