### PR TITLE
하현숙 programers 68645 삼각 달팽이

### DIFF
--- a/hyeonsook95/programers/68645.py
+++ b/hyeonsook95/programers/68645.py
@@ -1,0 +1,20 @@
+def solution(n):
+    maps = [[0 for _ in range(n)] for _ in range(n)]
+
+    dr = [1, 0, -1]
+    dc = [0, 1, -1]
+
+    r, c, d = 0, 0, 0
+    for num in range(1, (n * (n + 1) // 2) + 1):
+        maps[r][c] = num
+        if not (
+            -1 < r + dr[d] < n
+            and -1 < c + dc[d] <= r
+            and maps[r + dr[d]][c + dc[d]] == 0
+        ):
+            d = (d + 1) % 3
+        r += dr[d]
+        c += dc[d]
+
+    maps = [list(filter(lambda x: x != 0, m)) for m in maps]
+    return sum(maps, [])


### PR DESCRIPTION
# 17 삼각 달팽이
[문제 보러가기](https://programmers.co.kr/learn/courses/30/lessons/68645)

## 🅰 설계

삼각 달팽이 문제였기 때문에 자연스럽게 달팽이 문제가 떠올랐습니다.

달팽이 문제에서 확장해서 문제를 풀 수 있지 않을까 생각했고, 삼각형의 달팽이 모양이 아닌 2차원 배열을 채울 때 어떻게 채워질지 고민해보았습니다.

![삼각달팽이](https://user-images.githubusercontent.com/23014708/163819377-3221f51a-9758-4d00-bbfc-b50600f59295.jpg)

2차원 배열로 채운다고 생각하자 반을 0로 채우고 c의 범위 값을 조정해주면 달팽이 문제를 응용하여 풀 수 있겠다고 생각했습니다.

방향을 바꾸는 조건을 아래의 세 가지로 제한하고, 해당 조건을 만족하면 방향을 변경하도록 했습니다.

1. 다음 이동할 r의 위치가 `not -1 < 이동할 r < n`
2. 다음 이동할 c의 위치가 `not -1 < 이동할 c < r`
3. 다음 이동할 maps의 위치에 0이 아닌 다른 숫자가 채워져 있을 경우

```python3
    dr = [1, 0, -1]
    dc = [0, 1, -1]

    r, c, d = 0, 0, 0
    for num in range(1, (n * (n + 1) // 2) + 1):
        maps[r][c] = num
        if not (
            -1 < r + dr[d] < n
            and -1 < c + dc[d] <= r
            and maps[r + dr[d]][c + dc[d]] == 0
        ):
            d = (d + 1) % 3
        r += dr[d]
        c += dc[d]
```

그러면, 이차원 배열은 아래와 같이 만들어집니다.

```python3
[[1, 0, 0, 0], 
[2, 9, 0, 0], 
[3, 10, 8, 0], 
[4, 5, 6, 7]]
```

문제에서 주어진 출력의 값이 1차원 배열이므로 0을 제외하고, 2차원 배열을 1차원 배열로 변경한 후 값을 반환했습니다.

```python3
# 0을 제외한 2차원 배열로 변경
maps = [list(filter(lambda x: x != 0, m)) for m in maps]

# 2차원 배열을 1차원 배열로 변경 후 반환
return sum(maps, [])
```

## ✅ 후기

달팽이 문제에서 다양한 삽질을 해봤었기 때문에 비교적 쉽게 해결할 수 있었습니다.